### PR TITLE
Add data source to footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,6 +78,12 @@ body {
 #btns-export .right{
    padding:10px 0px;
 }
+
+footer {
+  margin-top: 2em;
+  text-align: center;
+}
+
 @media (max-width: 768px){
     #slider-number-control{
 	    padding-left:0px !important;

--- a/index.html
+++ b/index.html
@@ -103,7 +103,12 @@
 			</table>
 		</div>
 	</div>
-	
+
+  <div style="clear: both"></div>
+
+  <footer class="small">
+    <p>Data from <a href="https://data.sfgov.org/" target="_blank">SF OpenData</a>.</p>
+  </footer>
 </div>
 
     <!-- Load jQuery from Google's CDN, so that it is likely to be already in the client's cache -->


### PR DESCRIPTION
Added a link to [SF OpenData](https://data.sfgov.org/). Looks like this:

![screenshot](https://cloud.githubusercontent.com/assets/777712/17640757/34cc3a7e-60d5-11e6-937e-c19af92adbb1.png)

Addresses #24.
