### PR TITLE
Move crime-data specific code into a config file

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,11 +52,11 @@
                 <div class="row">
                     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                         <h1>San Francisco Crime Data</h1>
-                        <h2>SFPD data provided by <a href="https://data.sfgov.org/" target="_blank">SF OpenData</a></h2>   
+                        <h2>SFPD data provided by <a href="https://data.sfgov.org/" target="_blank">SF OpenData</a></h2>
                     </div>
                 </div>
-                
-                    <div id="sfim-controls" class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+
+                <div id="sfim-controls" class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                     <div id="address-control" class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
                         <div class="form-group" id="searchgroup">
                             <label for="inputAddress">Address</label>
@@ -223,7 +223,6 @@
         <script src="js/vendor/bootstrap3-typeahead.js"></script>
 
         <!-- Load services -->
-        <script src="js/services/endpoints.js"></script>
         <script src="js/services/addressService.js"></script>
         <script src="js/services/incidentService.js"></script>
 
@@ -238,6 +237,7 @@
         <script src="js/modules/page.js"></script>
 
         <!-- Start the application -->
+        <script src="js/config.js"></script>
         <script src="js/start.js"></script>
     </body>
 </html>

--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,52 @@
 var config = (function(window, $) {
 
+    var TABLE_COLUMNS = [{
+        data: "incidntnum",
+        title: "Incident#",
+        name: "incidntnum"
+    }, {
+        data: "date",
+        title: "Date",
+        name: "date",
+        render: function(data, type, row, meta) {
+            return moment(data).format('l');
+        },
+        visible: false
+    }, {
+        data: "time",
+        title: "Time",
+        name: "time",
+        visible: false
+    }, {
+        data: "address",
+        title: "Address",
+        name: "address",
+        visible: false
+    }, {
+        data: "pddistrict",
+        title: "District",
+        name: "pddistrict",
+        visible: false
+    }, {
+        className: "mobile",
+        data: "category",
+        title: "Category",
+        name: "category"
+    }, {
+        data: "descript",
+        title: "Description",
+        name: "descript"
+    }, {
+        className: "mobile tablet",
+        data: "resolution",
+        title: "Resolution",
+        name: "resolution"
+    }];
+
+    function popupContent(data) {
+        return data.descript + '; INCIDENT #: ' + data.incidntnum;
+    }
+
     return {
         incidentServiceOptions: {
             socrataResource: "cuks-n6tp",
@@ -7,48 +54,8 @@ var config = (function(window, $) {
             dateColumn: "date",
             locationColumn: "location"
         },
-        tableColumns: [{
-            data: "incidntnum",
-            title: "Incident#",
-            name: "incidntnum"
-        }, {
-            data: "date",
-            title: "Date",
-            name: "date",
-            render: function(data, type, row, meta) {
-                return moment(data).format('l');
-            },
-            visible: false
-        }, {
-            data: "time",
-            title: "Time",
-            name: "time",
-            visible: false
-        }, {
-            data: "address",
-            title: "Address",
-            name: "address",
-            visible: false
-        }, {
-            data: "pddistrict",
-            title: "District",
-            name: "pddistrict",
-            visible: false
-        }, {
-            className: "mobile",
-            data: "category",
-            title: "Category",
-            name: "category"
-        }, {
-            data: "descript",
-            title: "Description",
-            name: "descript"
-        }, {
-            className: "mobile tablet",
-            data: "resolution",
-            title: "Resolution",
-            name: "resolution"
-        }]
+        tableColumns: TABLE_COLUMNS,
+        popupContent: popupContent
     };
 
 })(window, jQuery);

--- a/js/config.js
+++ b/js/config.js
@@ -6,7 +6,49 @@ var config = (function(window, $) {
             timeColumn: "time",
             dateColumn: "date",
             locationColumn: "location"
-        }
+        },
+        tableColumns: [{
+            data: "incidntnum",
+            title: "Incident#",
+            name: "incidntnum"
+        }, {
+            data: "date",
+            title: "Date",
+            name: "date",
+            render: function(data, type, row, meta) {
+                return moment(data).format('l');
+            },
+            visible: false
+        }, {
+            data: "time",
+            title: "Time",
+            name: "time",
+            visible: false
+        }, {
+            data: "address",
+            title: "Address",
+            name: "address",
+            visible: false
+        }, {
+            data: "pddistrict",
+            title: "District",
+            name: "pddistrict",
+            visible: false
+        }, {
+            className: "mobile",
+            data: "category",
+            title: "Category",
+            name: "category"
+        }, {
+            data: "descript",
+            title: "Description",
+            name: "descript"
+        }, {
+            className: "mobile tablet",
+            data: "resolution",
+            title: "Resolution",
+            name: "resolution"
+        }]
     };
 
 })(window, jQuery);

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,12 @@
+var config = (function(window, $) {
+
+    return {
+        incidentServiceOptions: {
+            socrataResource: "cuks-n6tp",
+            timeColumn: "time",
+            dateColumn: "date",
+            locationColumn: "location"
+        }
+    };
+
+})(window, jQuery);

--- a/js/modules/datasetLinks.js
+++ b/js/modules/datasetLinks.js
@@ -1,23 +1,25 @@
 var datasetLinksModule = (function(window, $) {
 
     function _getCartoDbUrl(query) {
+        var incidentUrl = incidentService.buildIncidentDataUrl('geojson', query);
         return "//oneclick.cartodb.com/?"
-          + "file=" + encodeURIComponent(resourceEndpointsModule.INCIDENTS_API_GEOJSON_URL + query)
+          + "file=" + encodeURIComponent(incidentUrl)
           + "&provider=DataSF";
     }
 
     function _getCsvLink(query) {
-        return resourceEndpointsModule.INCIDENTS_API_CSV_URL + query;
+        return incidentService.buildIncidentDataUrl('csv', query);
     }
 
     function _getGeojsonio(query) {
+        var incidentUrl = incidentService.buildIncidentDataUrl('geojson', query);
         return "http://geojson.io/#"
-          + "data=data:text/x-url,"+ encodeURIComponent(resourceEndpointsModule.INCIDENTS_API_GEOJSON_URL + query);
+          + "data=data:text/x-url," + encodeURIComponent(incidentUrl);
     }
 
     function _setEmailLink() {
-      var link = encodeURIComponent(encodeURI(location.href));
-      return "mailto:?subject=My results from sfcrimedata.org&body=Here is the link to my search: %0A%0A" + link
+        var link = encodeURIComponent(encodeURI(location.href));
+        return "mailto:?subject=My results from sfcrimedata.org&body=Here is the link to my search: %0A%0A" + link;
     }
 
     function _refreshDownloadButtonUrls(query) {

--- a/js/modules/map.js
+++ b/js/modules/map.js
@@ -40,7 +40,11 @@ var mapModule = (function(window,$) {
 
     var map;
 
-    function _init() {
+    var generatePopupContent;
+
+    function _init(generatePopupContent_) {
+        generatePopupContent = generatePopupContent_;
+
         L.mapbox.accessToken = MAPBOX_ACCESS_TOKEN;
         map = L.mapbox.map(MAP_CONTAINER_ELEMENT_ID, MAPBOX_MAP_STYLE_ID);
 
@@ -103,15 +107,11 @@ var mapModule = (function(window,$) {
 
         incidentLayer.setGeoJSON(incidentGeoJson).eachLayer(function(layer) {
             incidentClusterGroup.addLayer(layer);
-            layer.bindPopup(_buildIncidentPopupContent(layer.feature.properties));
+            layer.bindPopup(generatePopupContent(layer.feature.properties));
         });
 
         incidentLayer.clearLayers();
         map.fitBounds(searchAreaGroup.getBounds());
-    }
-
-    function _buildIncidentPopupContent(properties) {
-        return properties.descript + '; INCIDENT #: ' + properties.incidntnum;
     }
 
     return {

--- a/js/modules/table.js
+++ b/js/modules/table.js
@@ -1,71 +1,32 @@
 var tableModule = (function(window, $) {
 
-    var TABLE_CONFIG = {
-        ajax: {
-            url: "empty.json",
-            dataSrc: ""
-        },
-        dom: '<"table-buttons"<"table-buttons"Bf>l>t<"table-buttons"ip>',
-        oLanguage: {
-            sSearch: "Filter results:"
-        },
-        buttons: [{ extend: 'colvis', text: 'Select Columns'}],
-        fixedHeader: {
-            header: true,
-            footer: true
-        },
-        columns: [{
-            data: "incidntnum",
-            title: "Incident#",
-            name: "incidntnum",
-        }, {
-            data: "date",
-            title: "Date",
-            name: "date",
-            render: function(data, type, row, meta) {
-                return moment(data).format('l')
-            },
-            visible: false
-        }, {
-            data: "time",
-            title: "Time",
-            name: "time",
-            visible: false
-        }, {
-            data: "address",
-            title: "Address",
-            name: "address",
-            visible: false
-        }, {
-            data: "pddistrict",
-            title: "District",
-            name: "pddistrict",
-            visible: false
-        }, {
-            className: "mobile",
-            data: "category",
-            title: "Category",
-            name: "category",
-        }, {
-            data: "descript",
-            title: "Description",
-            name: "descript",
-        }, {
-            className: "mobile tablet",
-            data: "resolution",
-            title: "Resolution",
-            name: "resolution",
-        }],
-        pageLength: 50,
-        footerCallback: function(tfoot, data, start, end, display) {
-            var dupHeaderRow = $(this.api().table().header()).children('tr:first').clone()
-        }
-    };
-
     var _table;
 
     function _init() {
-        _table = $('#example').DataTable(TABLE_CONFIG);
+        _table = $('#example').DataTable(_tableConfig());
+    }
+
+    function _tableConfig() {
+        return {
+            ajax: {
+                url: "empty.json",
+                dataSrc: ""
+            },
+            dom: '<"table-buttons"<"table-buttons"Bf>l>t<"table-buttons"ip>',
+            oLanguage: {
+                sSearch: "Filter results:"
+            },
+            buttons: [{ extend: 'colvis', text: 'Select Columns'}],
+            fixedHeader: {
+                header: true,
+                footer: true
+            },
+            columns: config.tableColumns,
+            pageLength: 50,
+            footerCallback: function(tfoot, data, start, end, display) {
+                var dupHeaderRow = $(this.api().table().header()).children('tr:first').clone()
+            }
+        };
     }
 
     function _loadDataToTable(incidentGeoJson) {

--- a/js/services/endpoints.js
+++ b/js/services/endpoints.js
@@ -1,9 +1,0 @@
-var resourceEndpointsModule = (function(window, $) {
-
-    return {
-        INCIDENTS_API_GEOJSON_URL: "https://data.sfgov.org/resource/cuks-n6tp.geojson",
-        INCIDENTS_API_JSON_URL: "https://data.sfgov.org/resource/cuks-n6tp.json",
-        INCIDENTS_API_CSV_URL: "https://data.sfgov.org/resource/cuks-n6tp.csv"
-    };
-
-})(window, jQuery);

--- a/js/services/incidentService.js
+++ b/js/services/incidentService.js
@@ -1,35 +1,69 @@
-var incidentService = (function(window, $) {
+var IncidentService = (function(window, $) {
 
-    var INCIDENTS_API_GEOJSON_URL = resourceEndpointsModule.INCIDENTS_API_GEOJSON_URL;
-    var INCIDENTS_API_JSON_URL = resourceEndpointsModule.INCIDENTS_API_JSON_URL;
+    var SOCRATA_BASE_URL = "https://data.sfgov.org/resource/";
 
-    function _findMostRecentIncident(callback) {
-        var query = "?$select=date,time"
+    function IncidentService(options) {
+        this.url = SOCRATA_BASE_URL + options.socrataResource;
+        this.timeColumn = options.timeColumn;
+        this.dateColumn = options.dateColumn;
+        this.locationColumn = options.locationColumn;
+    }
+
+    IncidentService.prototype.findMostRecentIncident = function(callback) {
+        var query = "$select=" + this.dateColumn + "," + this.timeColumn
           + "&$limit=1"
-          + "&$order=date DESC,time DESC";
+          + "&$order=" + this.dateColumn + "DESC," + this.timeColumn + " DESC";
+        var url = this.buildIncidentDataUrl('json', query);
 
-        $.get(INCIDENTS_API_JSON_URL + query, function(data) {
+        $.get(url, function(data) {
             callback(data[0]);
         });
-    }
+    };
 
-    function _findIncidentsWithPolygonSearch(searchParams, dataFormat, callback) {
-        var query = _buildPolygonIncidentDataQuery(searchParams);
-        var url = _buildIncidentDataUrl(dataFormat, query);
+    IncidentService.prototype.findIncidentsWithPolygonSearch = function(
+        searchParams, dataFormat, callback
+    ) {
+        var query = this.buildPolygonIncidentDataQuery(searchParams);
+        var url = this.buildIncidentDataUrl(dataFormat, query);
 
         $.get(url, callback);
-    }
+    };
 
-    function _buildPolygonIncidentDataQuery(params) {
+    IncidentService.prototype.findIncidentsWithRadialSearch = function(
+        searchParams, dataFormat, callback
+    ) {
+        var query = this.buildRadialIncidentDataQuery(searchParams);
+        var url = this.buildIncidentDataUrl(dataFormat, query);
+
+        $.get(url, callback);
+    };
+
+    IncidentService.prototype.buildPolygonIncidentDataQuery = function(params) {
         var wellKnownTextPolygon = _buildWellKnownTextFromGeoJson(params.searchGeoJson);
 
-        return "?$where="
-          + "date >= '" + params.startDate + "'"
-          + " AND date <= '" + params.endDate + "'"
-          + " AND within_polygon(location, \'" + wellKnownTextPolygon + "\')"
-          + "&$order=date DESC"
+        return "$where="
+          + this.dateColumn + " >= '" + params.startDate + "'"
+          + " AND " + this.dateColumn + " <= '" + params.endDate + "'"
+          + " AND within_polygon(" + this.locationColumn + ", \'" + wellKnownTextPolygon + "\')"
+          + "&$order=" + this.dateColumn + " DESC"
           + "&$limit=100000";
-    }
+    };
+
+    IncidentService.prototype.buildRadialIncidentDataQuery = function(params) {
+        return "$where="
+          + this.dateColumn + " >= '" + params.startDate + "'"
+          + " AND " + this.dateColumn + " <= '" + params.endDate + "'"
+          + " AND within_circle(" + this.locationColumn
+          + "," + params.latitude
+          + "," + params.longitude
+          + "," + params.radius + ")"
+          + "&$order=" + this.dateColumn + " DESC"
+          + "&$limit=100000";
+    };
+
+    IncidentService.prototype.buildIncidentDataUrl = function(dataFormat, query) {
+        return this.url + "." + dataFormat + "?" + query;
+    };
 
     function _buildWellKnownTextFromGeoJson(geoJson) {
         var coordinates = geoJson.geometry.coordinates[0].map(function(coord) {
@@ -39,37 +73,6 @@ var incidentService = (function(window, $) {
         return 'MULTIPOLYGON (((' + coordinates + ')))';
     }
 
-    function _findIncidentsWithRadialSearch(searchParams, dataFormat, callback) {
-        var query = _buildRadialIncidentDataQuery(searchParams);
-        var url = _buildIncidentDataUrl(dataFormat, query);
-
-        $.get(url, callback);
-    }
-
-    function _buildRadialIncidentDataQuery(params) {
-        return "?$where="
-          + "date >= '" + params.startDate + "'"
-          + " AND date <= '" + params.endDate + "'"
-          + " AND within_circle(location," +  params.latitude + "," + params.longitude + "," + params.radius + ")"
-          + "&$order=date DESC"
-          + "&$limit=100000";
-    }
-
-    function _buildIncidentDataUrl(dataFormat, query) {
-        var incidentsEndpoint = dataFormat === 'geojson'
-            ? INCIDENTS_API_GEOJSON_URL
-            : INCIDENTS_API_JSON_URL;
-
-        return incidentsEndpoint + query;
-    }
-
-    return {
-        findMostRecentIncident: _findMostRecentIncident,
-        findIncidentsWithPolygonSearch: _findIncidentsWithPolygonSearch,
-        findIncidentsWithRadialSearch: _findIncidentsWithRadialSearch,
-        buildPolygonIncidentDataQuery: _buildPolygonIncidentDataQuery,
-        buildRadialIncidentDataQuery: _buildRadialIncidentDataQuery
-    };
+    return IncidentService;
 
 })(window, jQuery);
-

--- a/js/start.js
+++ b/js/start.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
         window.incidentService = new IncidentService(config.incidentServiceOptions);
 
         formModule.init();
-        mapModule.init();
+        mapModule.init(config.popupContent);
         tableModule.init();
         urlSearchModule.initializeViewModelFromUrlParameters();
     }

--- a/js/start.js
+++ b/js/start.js
@@ -2,6 +2,8 @@ $(document).ready(function() {
     init();
 
     function init() {
+        window.incidentService = new IncidentService(config.incidentServiceOptions);
+
         formModule.init();
         mapModule.init();
         tableModule.init();


### PR DESCRIPTION
The intent is to generalize the code so that it can be used for other districts and datasets with as few changes as possible. All crime-data specific code and configuration is in a single configuration file. Using this as a base, it is very easy to visualize the fire data set using the same application. IMO, there is a huge benefit to keeping the crime data and fire risk data codebases as similar as possible so that new features and bugfixes in one can easily be ported over to the other.